### PR TITLE
print actuator name when clamping'

### DIFF
--- a/kinfer_sim/simulator.py
+++ b/kinfer_sim/simulator.py
@@ -233,6 +233,7 @@ class MujocoSimulator:
             act_type = joint_meta.actuator_type or "position"
             act_meta = self._metadata.actuator_type_to_metadata.get(act_type)
             self._actuators[joint_id] = create_actuator(
+                joint_name,
                 joint_meta,
                 act_meta,
                 dt=self._dt,


### PR DESCRIPTION
<img width="1671" height="31" alt="image" src="https://github.com/user-attachments/assets/e4ba2d3e-574e-42b0-8751-4200c19b4ba1" />

Log actuator name with clamp warning so you know which one it is.