### PR TITLE
fix a d  keyboard input direction

### DIFF
--- a/kinfer_sim/provider.py
+++ b/kinfer_sim/provider.py
@@ -179,9 +179,9 @@ class ControlVectorInputState(InputState):
         elif key == "s":
             self.value[0] -= self.STEP_SIZE
         elif key == "a":
-            self.value[1] -= self.STEP_SIZE
-        elif key == "d":
             self.value[1] += self.STEP_SIZE
+        elif key == "d":
+            self.value[1] -= self.STEP_SIZE
         elif key == "q":
             self.value[2] -= self.STEP_SIZE
         elif key == "e":
@@ -203,9 +203,9 @@ class ExpandedControlVectorInputState(InputState):
         elif key == "s":
             self.value[0] -= self.STEP_SIZE
         elif key == "a":
-            self.value[1] -= self.STEP_SIZE
-        elif key == "d":
             self.value[1] += self.STEP_SIZE
+        elif key == "d":
+            self.value[1] -= self.STEP_SIZE
         elif key == "q":
             self.value[2] -= self.STEP_SIZE
         elif key == "e":


### PR DESCRIPTION
This is because **left** is the **positive** y direction for our robot 

see https://docs.kscale.dev/docs/k-bot-motor-id-mapping

so pressing A which means go **left** should increment the y velocity command in the **positive** direction

and pressing D should increment it in the negative direction